### PR TITLE
Fix type of render in refactor-1.md

### DIFF
--- a/exercises/refactor-1.md
+++ b/exercises/refactor-1.md
@@ -54,7 +54,7 @@ For this challenge we are going to use a not very common representation of text:
 
 - Read the documentation of `Data.ByteString.Builder` from `bytestring` package.
 - Create a function `ppScore :: Int -> Builder` which pretty prints the score. Feel free to use a representation you like. Below you have some examples
-- Modify the function `render` to have type `:: RenderState -> Builder`. Of course, the render function should plot the score and the board itself
+- Modify the function `render` to have type `:: BoardInfo -> RenderState -> Builder`. Of course, the render function should plot the score and the board itself
 - clean errors the compiler gives. How do you print a `Builder` into the console?  (hint: check `IO` functions in the `Data.ByteString.Builder` [module](https://hackage.haskell.org/package/bytestring-0.10.6.0/docs/Data-ByteString-Builder.html))
 
 Here are some ways you can render the score:

--- a/exercises/refactor-4.md
+++ b/exercises/refactor-4.md
@@ -78,11 +78,11 @@ This task will expose you to a common pattern which is to define your monad stac
 Essentially, you are telling the compiler that your `GameStep` type has these capabilities. Probably you've found this repetitive. And it is!!, actually the compiler can do this for you.
 
 - In `RenderState.hs` define `newtype RenderStep m a = RenderStep {runRenderStep :: ReaderT BoardInfo (StateT RenderState m) a}`
-- Implement `Functor`, `Applicative`, `Monad`, `MonadState GameState`, `MonadReader BoardInfo` for `RenderStep` using `GeneralizedNewtypeDeriving`.
+- Implement `Functor`, `Applicative`, `Monad`, `MonadState RenderState`, `MonadReader BoardInfo` for `RenderStep` using `GeneralizedNewtypeDeriving`.
 
 ### Task 1.2: Abstract your functions
 
-- In every function using `GameStep` or `RenderStep` you should use `mtl` constraints. For example: if you have a function `fun :: GameStep a` now it will have type `fun :: (MonadState GameState, MonadReader BoardInfo) => m a`. This means _Don't use GameStep directly, but any monad with State and Read envs_
+- In every function using `GameStep` or `RenderStep` you should use `mtl` constraints. For example: if you have a function `fun :: GameStep a` now it will have type `fun :: (MonadState GameState m, MonadReader BoardInfo m) => m a`. This means _Don't use GameStep directly, but any monad with State and Read envs_
 
 - The functions you should change are:
   - `makeRandomPoint` from `GameState.hs`


### PR DESCRIPTION
The first refactoring exercise mentions to change the `render` function to `:: RenderState -> Builder` to use `Builder` instead of `String`. Unless I'm  missing something this should be `:: BoardInfo -> RenderState -> Builder`, since the `String` version also uses the `BoardInfo`. This might be potentially confusing.

Edit: + Fix more type signatures in `refactor-4.md`